### PR TITLE
Fix pre-commit hook setup instructions for NodeJS projects

### DIFF
--- a/.agents/skills/project/setup-pre-commit-hooks/SKILL.md
+++ b/.agents/skills/project/setup-pre-commit-hooks/SKILL.md
@@ -14,18 +14,23 @@ Set up pre-commit hooks for formatting, linting, and building using proper tooli
 Examine the repo to determine:
 
 1. **Stack** - Identify from existing config files (e.g., `Cargo.toml` → Rust, `package.json` → Node)
+   - For Node/TypeScript monorepos: also check that all workspace packages use the **same version** of shared tools (eslint, prettier, typescript). Mismatched versions (e.g., eslint 9 in one package, eslint 10 in another) require separate lint-staged patterns and should be fixed first.
 
-2. **Hook management tool** - Choose based on ecosystem:
+2. **Git root** - Before configuring any hook tooling, identify the actual git root. In nested worktree setups a subdirectory like `project/` may have its own `.git` file and be a completely separate repo — hook tooling installed there configures _that_ repo's hooks, not the parent's. Run `git -C <dir> rev-parse --git-dir` to confirm.
+
+3. **Hook management tool** - Choose based on ecosystem:
    - **Node/TypeScript**: Use [husky](https://typicode.github.io/husky/) + [lint-staged](https://github.com/lint-staged/lint-staged)
    - **Python**: Use [pre-commit](https://pre-commit.com)
    - **Go**: Use [lefthook](https://lefthook.dev/)
    - **Other**: Pick a proper tool for the ecosystem. The important thing is that you _do_ pick a proper tool instead of hand-rolling Git hooks.
 
-3. **Hook commands** - Infer from existing tooling (package.json scripts, linter configs like `.eslintrc`, `ruff.toml`). Default to at least these:
-   - Formatting
+4. **Hook commands** - Infer from existing tooling (package.json scripts, linter configs like `.eslintrc`, `ruff.toml`). Default to at least these:
+   - Formatting — run prettier on **all file types it supports**, not just source files. For lint-staged: `"**/*.{js,ts,jsx,tsx,json,md,yaml,yml,css,scss,html}": "prettier --write"`.
    - Linting
    - Type-checking (for languages such as Python that won't otherwise encounter type-checking)
-   - Building (for languages such as Rust that have a build step)
+     - **TypeScript:** use `tsc --noEmit` (type-check only). Full builds belong in CI, not pre-commit.
+     - **TypeScript + lint-staged:** `tsc` cannot receive individual staged file paths — `tsc -p tsconfig.json file.ts` throws TS5042, and `tsc --noEmit file.ts` ignores tsconfig compilerOptions. `tsc-files` is abandoned and broken with TypeScript 6+. The correct solution is a `lint-staged.config.js` (not `package.json`) using function syntax so tsc runs project-wide without file args: `"**/*.ts": () => "pnpm --filter <pkg> typecheck"`. See: https://github.com/lint-staged/lint-staged/issues/825#issuecomment-2393146853
+   - Building (for languages such as Rust that have a compiled build step — not TypeScript)
 
    **Do NOT include tests in pre-commit hooks** - tests should run in CI to keep commits fast. Pre-commit hooks should only include fast checks that validate code quality, not test suites.
 

--- a/docs/wiki/project/setup-pre-commit-hooks.md
+++ b/docs/wiki/project/setup-pre-commit-hooks.md
@@ -14,18 +14,23 @@ Set up pre-commit hooks for formatting, linting, and building using proper tooli
 Examine the repo to determine:
 
 1. **Stack** - Identify from existing config files (e.g., `Cargo.toml` → Rust, `package.json` → Node)
+   - For Node/TypeScript monorepos: also check that all workspace packages use the **same version** of shared tools (eslint, prettier, typescript). Mismatched versions (e.g., eslint 9 in one package, eslint 10 in another) require separate lint-staged patterns and should be fixed first.
 
-2. **Hook management tool** - Choose based on ecosystem:
+2. **Git root** - Before configuring any hook tooling, identify the actual git root. In nested worktree setups a subdirectory like `project/` may have its own `.git` file and be a completely separate repo — hook tooling installed there configures _that_ repo's hooks, not the parent's. Run `git -C <dir> rev-parse --git-dir` to confirm.
+
+3. **Hook management tool** - Choose based on ecosystem:
    - **Node/TypeScript**: Use [husky](https://typicode.github.io/husky/) + [lint-staged](https://github.com/lint-staged/lint-staged)
    - **Python**: Use [pre-commit](https://pre-commit.com)
    - **Go**: Use [lefthook](https://lefthook.dev/)
    - **Other**: Pick a proper tool for the ecosystem. The important thing is that you _do_ pick a proper tool instead of hand-rolling Git hooks.
 
-3. **Hook commands** - Infer from existing tooling (package.json scripts, linter configs like `.eslintrc`, `ruff.toml`). Default to at least these:
-   - Formatting
+4. **Hook commands** - Infer from existing tooling (package.json scripts, linter configs like `.eslintrc`, `ruff.toml`). Default to at least these:
+   - Formatting — run prettier on **all file types it supports**, not just source files. For lint-staged: `"**/*.{js,ts,jsx,tsx,json,md,yaml,yml,css,scss,html}": "prettier --write"`.
    - Linting
    - Type-checking (for languages such as Python that won't otherwise encounter type-checking)
-   - Building (for languages such as Rust that have a build step)
+     - **TypeScript:** use `tsc --noEmit` (type-check only). Full builds belong in CI, not pre-commit.
+     - **TypeScript + lint-staged:** `tsc` cannot receive individual staged file paths — `tsc -p tsconfig.json file.ts` throws TS5042, and `tsc --noEmit file.ts` ignores tsconfig compilerOptions. `tsc-files` is abandoned and broken with TypeScript 6+. The correct solution is a `lint-staged.config.js` (not `package.json`) using function syntax so tsc runs project-wide without file args: `"**/*.ts": () => "pnpm --filter <pkg> typecheck"`. See: https://github.com/lint-staged/lint-staged/issues/825#issuecomment-2393146853
+   - Building (for languages such as Rust that have a compiled build step — not TypeScript)
 
    **Do NOT include tests in pre-commit hooks** - tests should run in CI to keep commits fast. Pre-commit hooks should only include fast checks that validate code quality, not test suites.
 

--- a/src/mekara/bundled/scripts/nl/project/setup-pre-commit-hooks/SKILL.md
+++ b/src/mekara/bundled/scripts/nl/project/setup-pre-commit-hooks/SKILL.md
@@ -14,18 +14,23 @@ Set up pre-commit hooks for formatting, linting, and building using proper tooli
 Examine the repo to determine:
 
 1. **Stack** - Identify from existing config files (e.g., `Cargo.toml` → Rust, `package.json` → Node)
+   - For Node/TypeScript monorepos: also check that all workspace packages use the **same version** of shared tools (eslint, prettier, typescript). Mismatched versions (e.g., eslint 9 in one package, eslint 10 in another) require separate lint-staged patterns and should be fixed first.
 
-2. **Hook management tool** - Choose based on ecosystem:
+2. **Git root** - Before configuring any hook tooling, identify the actual git root. In nested worktree setups a subdirectory like `project/` may have its own `.git` file and be a completely separate repo — hook tooling installed there configures _that_ repo's hooks, not the parent's. Run `git -C <dir> rev-parse --git-dir` to confirm.
+
+3. **Hook management tool** - Choose based on ecosystem:
    - **Node/TypeScript**: Use [husky](https://typicode.github.io/husky/) + [lint-staged](https://github.com/lint-staged/lint-staged)
    - **Python**: Use [pre-commit](https://pre-commit.com)
    - **Go**: Use [lefthook](https://lefthook.dev/)
    - **Other**: Pick a proper tool for the ecosystem. The important thing is that you _do_ pick a proper tool instead of hand-rolling Git hooks.
 
-3. **Hook commands** - Infer from existing tooling (package.json scripts, linter configs like `.eslintrc`, `ruff.toml`). Default to at least these:
-   - Formatting
+4. **Hook commands** - Infer from existing tooling (package.json scripts, linter configs like `.eslintrc`, `ruff.toml`). Default to at least these:
+   - Formatting — run prettier on **all file types it supports**, not just source files. For lint-staged: `"**/*.{js,ts,jsx,tsx,json,md,yaml,yml,css,scss,html}": "prettier --write"`.
    - Linting
    - Type-checking (for languages such as Python that won't otherwise encounter type-checking)
-   - Building (for languages such as Rust that have a build step)
+     - **TypeScript:** use `tsc --noEmit` (type-check only). Full builds belong in CI, not pre-commit.
+     - **TypeScript + lint-staged:** `tsc` cannot receive individual staged file paths — `tsc -p tsconfig.json file.ts` throws TS5042, and `tsc --noEmit file.ts` ignores tsconfig compilerOptions. `tsc-files` is abandoned and broken with TypeScript 6+. The correct solution is a `lint-staged.config.js` (not `package.json`) using function syntax so tsc runs project-wide without file args: `"**/*.ts": () => "pnpm --filter <pkg> typecheck"`. See: https://github.com/lint-staged/lint-staged/issues/825#issuecomment-2393146853
+   - Building (for languages such as Rust that have a compiled build step — not TypeScript)
 
    **Do NOT include tests in pre-commit hooks** - tests should run in CI to keep commits fast. Pre-commit hooks should only include fast checks that validate code quality, not test suites.
 


### PR DESCRIPTION
Updates the `setup-pre-commit-hooks` skill/script with Node/TypeScript-specific guidance learned from real usage:

- Add a **Git root** identification step before configuring hook tooling, to avoid accidentally configuring hooks on a nested sub-repo instead of the parent
- Add monorepo note: check that all workspace packages use the same version of shared tools (eslint, prettier, typescript) before setting up lint-staged
- Expand formatting guidance: run prettier on all supported file types, not just source files
- Add TypeScript-specific type-checking guidance: use `tsc --noEmit` (not a full build), and document the `lint-staged` + `tsc` incompatibility workaround using `lint-staged.config.js` with function syntax
- Clarify that the "building" hook step applies to compiled languages like Rust, not TypeScript