### PR TITLE
Fix hook detection for multi-line prompts and document the fix

### DIFF
--- a/docs/docs/code-base/mekara/hooks.md
+++ b/docs/docs/code-base/mekara/hooks.md
@@ -191,3 +191,23 @@ Both hooks normalize command names by:
 - Converting colons to slashes (`test:random` → `test/random`)
 
 This ensures consistent resolution regardless of how the user types the command.
+
+### Prompt Parsing for reroute-user-commands
+
+The `reroute-user-commands` hook parses the raw user prompt to extract the command name and arguments via `parse_slash_command()` in `src/mekara/cli.py`.
+
+:::warning[Multi-line argument pitfall]
+Arguments can span multiple lines when users paste context after a command (e.g., `/start <multi-line description>`). A regex like `^//?(command)(?:\s+(.*))?$` silently fails here: `(.*)` stops at the first newline, so `$` never matches end-of-string, and the entire match returns `None` — the hook outputs nothing.
+
+The fix is to match only the command name at the start and take everything after it as raw text:
+
+```python
+# Wrong: $ anchor breaks on multi-line args
+match = re.match(r"^//?(/?[a-zA-Z0-9_/:/-]+)(?:\s+(.*))?$", prompt.strip())
+
+# Right: match command name, capture rest verbatim
+match = re.match(r"^//?(/?[a-zA-Z0-9_/:/-]+)", prompt.strip())
+arguments = prompt.strip()[match.end():].lstrip()
+```
+
+:::

--- a/src/mekara/cli.py
+++ b/src/mekara/cli.py
@@ -25,6 +25,21 @@ def _env_bool(name: str) -> bool:
     return val in ("true", "1", "yes")
 
 
+def parse_slash_command(prompt: str) -> tuple[str, str] | None:
+    """Parse a /command prompt into (command_name, arguments).
+
+    Handles single and double leading slashes, colon and slash path separators.
+    Arguments may span multiple lines. Returns None if not a slash command.
+    """
+    stripped = prompt.strip()
+    match = re.match(r"^//?(/?[a-zA-Z0-9_/:/-]+)", stripped)
+    if not match:
+        return None
+    command_name = match.group(1).lstrip("/")
+    arguments = stripped[match.end() :].lstrip()
+    return command_name, arguments
+
+
 # Create Click group (main CLI)
 @click.group(
     help="Your automation Mecha.",
@@ -280,17 +295,11 @@ def _hook_user_prompt_submit() -> int:
     if not prompt:
         return 0
 
-    # Check if prompt starts with / or // followed by a command name
-    # Double-slash is treated identically to single-slash (first slash ignored)
-    # Claude Code may use : or / as path separators (e.g., /test:random or /test/random)
-    match = re.match(r"^//?(/?[a-zA-Z0-9_/:/-]+)(?:\s+(.*))?$", prompt.strip())
-    if not match:
+    parsed = parse_slash_command(prompt)
+    if parsed is None:
         return 0
 
-    command_name = match.group(1)
-    # Strip any leading slash from the command name (handles // case)
-    command_name = command_name.lstrip("/")
-    arguments = match.group(2) or ""
+    command_name, arguments = parsed
 
     # Normalize: convert colons to slashes for mekara resolution
     command_name_normalized = command_name.replace(":", "/")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -14,8 +14,48 @@ from mekara.cli import (
     _hook_pre_tool_use,
     _hook_user_prompt_submit,
     _install_commands,
+    parse_slash_command,
 )
 from mekara.scripting.resolution import ResolvedTarget, ScriptInfo
+
+
+class TestParseSlashCommand:
+    def test_simple_command_no_args(self) -> None:
+        assert parse_slash_command("/finish") == ("finish", "")
+
+    def test_command_with_single_line_args(self) -> None:
+        assert parse_slash_command("/start my feature") == ("start", "my feature")
+
+    def test_command_with_multiline_args(self) -> None:
+        prompt = "/start line one\n\nline two\nline three"
+        assert parse_slash_command(prompt) == ("start", "line one\n\nline two\nline three")
+
+    def test_double_slash_treated_as_single(self) -> None:
+        assert parse_slash_command("//finish") == ("finish", "")
+        assert parse_slash_command("//start arg") == ("start", "arg")
+
+    def test_colon_separator_preserved(self) -> None:
+        assert parse_slash_command("/test:random") == ("test:random", "")
+
+    def test_slash_separator_preserved(self) -> None:
+        assert parse_slash_command("/test/random some args") == ("test/random", "some args")
+
+    def test_not_a_slash_command(self) -> None:
+        assert parse_slash_command("hello world") is None
+        assert parse_slash_command("") is None
+
+    def test_leading_whitespace_ignored(self) -> None:
+        assert parse_slash_command("  /finish  ") == ("finish", "")
+
+    def test_multiline_args_fully_captured(self) -> None:
+        prompt = "/start Three fixes:\n\n  1. fix one\n  2. fix two\n\nmake it optional"
+        result = parse_slash_command(prompt)
+        assert result is not None
+        name, args = result
+        assert name == "start"
+        assert "Three fixes:" in args
+        assert "fix two" in args
+        assert "make it optional" in args
 
 
 class TestCommandAffectsAgentsDir:


### PR DESCRIPTION
The `reroute-user-commands` hook previously failed silently on multi-line prompts because the parsing regex used (.*)$ which stops at the first newline. This extracted a reusable `parse_slash_command()` function that correctly detects slash commands in multi-line input, added comprehensive test coverage, and documented the pitfall and solution.