### PR TITLE
Improve release skill and bundled sync warnings

### DIFF
--- a/.agents/skills/project/release/SKILL.md
+++ b/.agents/skills/project/release/SKILL.md
@@ -134,3 +134,4 @@ Wait for the user to confirm successful install before creating the release.
 - **Verify before publishing**: Always build and verify the package contents before handing off to the user for publishing
 - **Test on TestPyPI first**: TestPyPI exists specifically for testing the full publish/install flow without affecting the real PyPI index
 - **User publishes manually**: The user should always manually run the publish command after reviewing the prepared package—never auto-publish
+

--- a/.agents/skills/project/release/SKILL.md
+++ b/.agents/skills/project/release/SKILL.md
@@ -28,7 +28,7 @@ Releases must start from a clean main branch with no uncommitted or unpushed cha
 Gather the following information from the user-provided context:
 - Target version (e.g., `0.1.0a1` for first alpha, `0.1.0` for stable)
 
-If unclear, ask the user for the target version.
+If unclear, look up the current published version on PyPI and suggest the next patch increment (e.g., if `0.1.1` is published, suggest `0.1.2`). Ask the user to confirm or provide a different version.
 
 ### Step 2: Check for broken external links
 
@@ -113,10 +113,18 @@ poetry publish
 
 After the user confirms the package installs and runs correctly from PyPI, create a git tag and GitHub release:
 
+First, find the previous version tag to use as the start of the release notes:
+
+```bash
+git tag --sort=-version:refname | grep '^v' | sed -n '2p'
+```
+
+Then create the tag and release, scoping notes to only changes since the previous tag:
+
 ```bash
 git tag v<target-version>
 git push origin v<target-version>
-gh release create v<target-version> --title "v<target-version>" --generate-notes
+gh release create v<target-version> --title "v<target-version>" --generate-notes --notes-start-tag v<previous-version>
 ```
 
 Wait for the user to confirm successful install before creating the release.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,7 @@ repos:
         entry: poetry run python3 scripts/sync_nl.py
         language: system
         pass_filenames: false
+        verbose: true
         files: ^(\.agents/skills/|src/mekara/bundled/skills/|docs/wiki/)
       - id: skill-frontmatter
         name: Skill frontmatter validation

--- a/docs/docs/code-base/mekara/bundled-script-generalization.md
+++ b/docs/docs/code-base/mekara/bundled-script-generalization.md
@@ -103,10 +103,14 @@ If a bundled NL skill is _not_ intentionally generalized (i.e. it's not present 
 - TestPyPI publish commands, `pip install --index-url ...`, `mekara --version` verification → replaced with generic "publish to appropriate registry" instructions
 - Duplicate "Step 5" numbering bug fixed (publish step renumbered to Step 6)
 
+**Changed:**
+
+- Step 1: "look up PyPI and suggest next patch increment" → "look up the appropriate registry and suggest the next patch increment"
+- Step 7 (GitHub release): kept as-is — `--notes-start-tag` and tag/push commands are fully generic
+
 **Kept:**
 
 - Step 0 clean main branch check (generic)
-- Step 1 version gathering (generic)
 - Step 4 Docusaurus snapshot (made conditional — "if the project uses Docusaurus versioning")
 - Key Principles (removed TestPyPI-specific principle, kept verify-before-publish and user-publishes-manually)
 

--- a/docs/docs/code-base/mekara/scripts.md
+++ b/docs/docs/code-base/mekara/scripts.md
@@ -133,7 +133,7 @@ Syncs natural language scripts between `.agents/skills/`, `docs/wiki/`, and `src
 - Flags conflicts when the same script is staged in two sources with differing content
 - Validates that bundled NL/compiled pairs are updated together
 - Treats bundled skills as single directories under `src/mekara/bundled/skills/<skill>/`, with `SKILL.md` and `mekara.py` side by side
-- Excludes generalized scripts (listed in `bundled-script-generalization.md`) from `.agents` ↔ wiki sync
+- Excludes generalized scripts (listed in `bundled-script-generalization.md`) from `.agents` ↔ wiki sync; prints a reminder to manually update the bundled version when a generalized script is staged
 - Top-level scripts (no category subdirectory) are excluded from wiki but synced to bundled
 
 **When it runs:**

--- a/docs/docs/development/git-hooks.md
+++ b/docs/docs/development/git-hooks.md
@@ -65,7 +65,7 @@ Bundled skills in `src/mekara/bundled/skills/` are edited independently (no auto
 
 1. **Validates generalized NL/compiled pairs** — if a bundled NL skill listed in `bundled-script-generalization.md` changes and a corresponding bundled compiled file exists, that compiled file must also change in the same commit
 2. **Validates non-generalized compiled equality** — if both `.agents/skills/<skill>/mekara.py` and `src/mekara/bundled/skills/<skill>/mekara.py` exist and the skill is not listed in `bundled-script-generalization.md`, those two compiled files must be exactly identical
-3. **Alerts on potential sync needs** — warns when `.agents/skills/` or bundled skills change without corresponding changes in the other location, prompting you to check if synced updates are needed
+3. **Alerts on potential sync needs** — warns when `.agents/skills/` or bundled skills change without corresponding changes in the other location, prompting you to check if synced updates are needed. For generalized skills (listed in `bundled-script-generalization.md`), the message is specific: it names the exact bundled file that needs manual review. This output is always visible because the hook has `verbose: true` set in `.pre-commit-config.yaml`, which causes pre-commit to show hook output even when the hook passes.
 
    When the hook requires a generated or compiled file update, the agent should be informed that the file update should reflect the real source change. The agent should not add filler comments or docstrings just to force a diff.
 

--- a/docs/wiki/project/release.md
+++ b/docs/wiki/project/release.md
@@ -30,7 +30,7 @@ Gather the following information from the user-provided context:
 
 - Target version (e.g., `0.1.0a1` for first alpha, `0.1.0` for stable)
 
-If unclear, ask the user for the target version.
+If unclear, look up the currently published version on the appropriate registry and suggest the next patch increment (e.g., if `0.1.1` is published, suggest `0.1.2`). Ask the user to confirm or provide a different version.
 
 ### Step 2: Check for broken external links
 
@@ -69,6 +69,22 @@ Build the distribution using the project's build tool (e.g., `poetry build`, `ca
 ### Step 6: Provide publishing instructions
 
 Tell the user the package is ready and provide instructions for publishing to the appropriate registry (e.g., PyPI, crates.io, npm). Recommend testing on a staging registry first if one is available.
+
+### Step 7: Create release tag and GitHub release
+
+After the user confirms the package is published successfully, create a git tag and GitHub release. First, find the previous version tag to scope the release notes:
+
+```bash
+git tag --sort=-version:refname | grep '^v' | sed -n '2p'
+```
+
+Then create the tag and release:
+
+```bash
+git tag v<target-version>
+git push origin v<target-version>
+gh release create v<target-version> --title "v<target-version>" --generate-notes --notes-start-tag v<previous-version>
+```
 
 ## Key Principles
 

--- a/scripts/sync_nl.py
+++ b/scripts/sync_nl.py
@@ -347,7 +347,7 @@ def _check_bundled_nl_compiled(changed: set[str], repo_root: Path) -> int:
     return 0
 
 
-def _warn_sync_mismatch(changed: set[str], repo_root: Path) -> None:
+def _warn_sync_mismatch(changed: set[str], repo_root: Path, generalized: set[str]) -> None:
     """Warn when .mekara and bundled scripts change without corresponding updates."""
     nl_changed = any(changed_skill_relative(f, LOCAL_SKILLS_PREFIX) is not None for f in changed)
     bundled_nl_changed = any(changed_skill_relative(f, BUNDLED_SKILLS_PREFIX) is not None for f in changed)
@@ -358,12 +358,17 @@ def _warn_sync_mismatch(changed: set[str], repo_root: Path) -> None:
             if relative is None:
                 continue
             bundled = f"{BUNDLED_SKILLS_PREFIX}{relative.removesuffix('.md')}/SKILL.md"
-            if (repo_root / bundled).exists():
-                print()
+            if not (repo_root / bundled).exists():
+                continue
+            print()
+            if relative in generalized:
+                print(f"Note: {nl_file} is a generalized script.")
+                print(f"Manually update {bundled} to reflect any applicable changes.")
+            else:
                 print("Warning: .agents/skills/ changed but bundled scripts didn't.")
                 print("Check if src/mekara/bundled/skills/ needs corresponding updates.")
-                print()
-                break
+            print()
+            break
 
     if bundled_nl_changed and not nl_changed:
         for bundled_file in changed:
@@ -420,7 +425,7 @@ def main() -> int:
     if _check_non_generalized_compiled_match(repo_root, generalized) != 0:
         return 1
 
-    _warn_sync_mismatch(changed, repo_root)
+    _warn_sync_mismatch(changed, repo_root, generalized)
     return 0
 
 

--- a/src/mekara/bundled/skills/project/release/SKILL.md
+++ b/src/mekara/bundled/skills/project/release/SKILL.md
@@ -30,7 +30,7 @@ Gather the following information from the user-provided context:
 
 - Target version (e.g., `0.1.0a1` for first alpha, `0.1.0` for stable)
 
-If unclear, ask the user for the target version.
+If unclear, look up the currently published version on the appropriate registry and suggest the next patch increment (e.g., if `0.1.1` is published, suggest `0.1.2`). Ask the user to confirm or provide a different version.
 
 ### Step 2: Check for broken external links
 
@@ -69,6 +69,22 @@ Build the distribution using the project's build tool (e.g., `poetry build`, `ca
 ### Step 6: Provide publishing instructions
 
 Tell the user the package is ready and provide instructions for publishing to the appropriate registry (e.g., PyPI, crates.io, npm). Recommend testing on a staging registry first if one is available.
+
+### Step 7: Create release tag and GitHub release
+
+After the user confirms the package is published successfully, create a git tag and GitHub release. First, find the previous version tag to scope the release notes:
+
+```bash
+git tag --sort=-version:refname | grep '^v' | sed -n '2p'
+```
+
+Then create the tag and release:
+
+```bash
+git tag v<target-version>
+git push origin v<target-version>
+gh release create v<target-version> --title "v<target-version>" --generate-notes --notes-start-tag v<previous-version>
+```
 
 ## Key Principles
 


### PR DESCRIPTION
- Release skill now suggests next patch version automatically by looking up the current published version on the registry, instead of just asking the user
- Release skill now creates GitHub releases with `--notes-start-tag` scoped to the previous tag, preventing release notes from including unrelated earlier commits
- Bundled skill sync hook (`sync_nl.py`) now prints specific, actionable messages for generalized scripts (naming the exact bundled file to update manually) rather than generic warnings
- Pre-commit hook has `verbose: true` so sync warnings are always visible even when the hook passes
- Documentation updated to reflect the above changes