### PR TITLE
Remove settings.local.json from worktree init and teardown

### DIFF
--- a/.agents/skills/finish/SKILL.md
+++ b/.agents/skills/finish/SKILL.md
@@ -82,10 +82,6 @@ Run `cd ../main && git pull` to update our local version of main
 
 Update dependencies on main after the merge: run `cd ../main && poetry install --with dev` and `cd ../main && pnpm --dir docs/ install --frozen-lockfile`. This ensures the main environment is in sync with any new dependencies that were added during this PR.
 
-### Step 13: Sync local settings
-
-If everything was successful, read `.claude/settings.local.json` and manually update `../main/.claude/settings.local.json` with any new permissions. **Do NOT use `cp`** as this would overwrite settings that may have been added in other worktree branches.
-
-### Step 14: Tear down worktree
+### Step 13: Tear down worktree
 
 Run `/teardown-worktree` to remove the virtual environment, delete the remote branch if it exists, and remove the worktree directory and local branch.

--- a/.agents/skills/finish/mekara.py
+++ b/.agents/skills/finish/mekara.py
@@ -224,13 +224,5 @@ def execute(request: str):
         "cd ../main && pnpm --dir docs/ install --frozen-lockfile", context=main_deps_context
     )
 
-    # Step 13: Sync local settings
-    yield llm(
-        "If everything was successful, read `.claude/settings.local.json` and manually "
-        "update `../main/.claude/settings.local.json` with any new permissions. "
-        "**Do NOT use `cp`** as this would overwrite settings that may have been added "
-        "in other worktree branches."
-    )
-
-    # Step 14: Tear down worktree
+    # Step 13: Tear down worktree
     yield call_script("teardown-worktree")

--- a/.agents/skills/setup-worktree/SKILL.md
+++ b/.agents/skills/setup-worktree/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: setup-worktree
-description: Set up a new git worktree, install dependencies, and copy local settings.
+description: Set up a new git worktree and install dependencies.
 ---
 
-Sets up a new git worktree for development, installing all dependencies and copying local settings. Takes the branch name as `$ARGUMENTS`.
+Sets up a new git worktree for development, installing all dependencies. Takes the branch name as `$ARGUMENTS`.
 
 <UserContext>$ARGUMENTS</UserContext>
 
@@ -21,11 +21,6 @@ Install Python dev dependencies with `poetry install --with dev`.
 
 Install `docs/` dependencies with `pnpm --dir docs/ i --frozen-lockfile`.
 
-### Step 3: Copy settings
-
-Copy settings with `cp .claude/settings.local.json ../<branch-name>/.claude/settings.local.json`.
-
 ## Key Principles
 
 - **Run install steps in the new worktree**: Steps 1 and 2 must run inside `../<branch-name>`, not the current directory.
-- **Copy, don't symlink**: Settings are copied so each worktree has its own independent copy.

--- a/.agents/skills/setup-worktree/mekara.py
+++ b/.agents/skills/setup-worktree/mekara.py
@@ -32,11 +32,3 @@ def execute(request: str):
         context="Install `docs/` dependencies with `pnpm --dir docs/ i --frozen-lockfile`",
     )
 
-    # Step 3: Copy settings
-    yield auto(
-        f"cp .claude/settings.local.json ../{branch}/.claude/settings.local.json",
-        context=(
-            "Copy settings with `cp .claude/settings.local.json "
-            "../<branch-name>/.claude/settings.local.json`."
-        ),
-    )

--- a/docs/docs/code-base/mekara/bundled-script-generalization.md
+++ b/docs/docs/code-base/mekara/bundled-script-generalization.md
@@ -62,7 +62,6 @@ If a bundled NL skill is _not_ intentionally generalized (i.e. it's not present 
 - Worktree workflow
 - `/merge-main` script call
 - GitHub PR workflow with auto-merge
-- `.claude/settings.local.json` syncing (made conditional)
 - `main/` directory name
 - CI checks concept (generalized)
 
@@ -135,8 +134,7 @@ If a bundled NL skill is _not_ intentionally generalized (i.e. it's not present 
 **Kept:**
 
 - `mekara/` branch prefix and worktree creation
-- `.claude/settings.local.json` copy to new worktree
-- Key Principles (updated to reference Step 2 only)
+- Key Principles (updated to reference Step 1 only)
 
 ### standardize.md
 

--- a/docs/docs/roadmap/setup-teardown-worktree-scripts.md
+++ b/docs/docs/roadmap/setup-teardown-worktree-scripts.md
@@ -56,7 +56,6 @@ Takes `$ARGUMENTS` as the branch name. Steps:
 1. Create worktree: `git worktree add -b mekara/<branch> ../<branch>` — if the branch already exists, choose a different name
 2. Install Python deps: `cd ../<branch> && poetry install --with dev`
 3. Install docs deps: `cd ../<branch> && pnpm --dir docs/ i --frozen-lockfile`
-4. Copy settings: `cp .claude/settings.local.json ../<branch>/.claude/settings.local.json`
 
 ### `/teardown-worktree`
 
@@ -70,7 +69,7 @@ No arguments — auto-detects from the current directory. Steps:
 
 ### Invariants
 
-- `/setup-worktree` is always called from the `main` worktree (where `.claude/settings.local.json` lives)
+- `/setup-worktree` is always called from the `main` worktree
 - `/teardown-worktree` is always called from inside the worktree being torn down
 
 ## Implementation Plan

--- a/src/mekara/bundled/skills/finish/SKILL.md
+++ b/src/mekara/bundled/skills/finish/SKILL.md
@@ -99,10 +99,6 @@ Examples:
 - Node/pnpm: `cd ../main && pnpm install --frozen-lockfile`
 - Rust/Cargo: `cd ../main && cargo build`
 
-### Step 13: Sync local settings
-
-If the project uses `.claude/settings.local.json` (or similar local configuration), read the worktree's version and manually update `../main/.claude/settings.local.json` with any new permissions or settings. **Do NOT use `cp`** as this would overwrite settings that may have been added in other worktree branches.
-
-### Step 14: Tear down worktree
+### Step 13: Tear down worktree
 
 Run `/teardown-worktree` to remove the virtual environment, delete the remote branch if it exists, and remove the worktree directory and local branch.

--- a/src/mekara/bundled/skills/finish/mekara.py
+++ b/src/mekara/bundled/skills/finish/mekara.py
@@ -224,13 +224,5 @@ def execute(request: str):
         "cd ../main && pnpm --dir docs/ install --frozen-lockfile", context=main_deps_context
     )
 
-    # Step 13: Sync local settings
-    yield llm(
-        "If everything was successful, read `.claude/settings.local.json` and manually "
-        "update `../main/.claude/settings.local.json` with any new permissions. "
-        "**Do NOT use `cp`** as this would overwrite settings that may have been added "
-        "in other worktree branches."
-    )
-
-    # Step 14: Tear down worktree
+    # Step 13: Tear down worktree
     yield call_script("teardown-worktree")

--- a/src/mekara/bundled/skills/setup-worktree/SKILL.md
+++ b/src/mekara/bundled/skills/setup-worktree/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: setup-worktree
-description: Set up a new git worktree, install dependencies, and copy local settings.
+description: Set up a new git worktree and install dependencies.
 ---
 
-Sets up a new git worktree for development, installing all dependencies and copying local settings. Takes the branch name as `$ARGUMENTS`.
+Sets up a new git worktree for development, installing all dependencies. Takes the branch name as `$ARGUMENTS`.
 
 <UserContext>$ARGUMENTS</UserContext>
 
@@ -27,11 +27,6 @@ Check the project's README or build configuration to determine the correct comma
 
 If there's multiple stacks used within the project, run the appropriate setup commands for all stacks.
 
-### Step 2: Copy settings
-
-Copy settings with `cp .claude/settings.local.json ../<branch-name>/.claude/settings.local.json`.
-
 ## Key Principles
 
 - **Run install steps in the new worktree**: Step 1 must run inside `../<branch-name>`, not the current directory.
-- **Copy, don't symlink**: Settings are copied so each worktree has its own independent copy.


### PR DESCRIPTION
Removes `settings.local.json` creation and deletion from the `setup-worktree` and `finish`/`teardown-worktree` skills. The worktree scripts no longer manage this file.